### PR TITLE
add an undname binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ repository = "https://github.com/mstange/msvc-demangler-rust"
 
 [dependencies]
 bitflags = "1.0.1"
+
+[[bin]]
+name = "undname"

--- a/src/bin/undname.rs
+++ b/src/bin/undname.rs
@@ -1,0 +1,38 @@
+extern crate msvc_demangler;
+
+use std::env;
+use std::io;
+use std::io::BufRead;
+
+fn main() {
+    let args = env::args();
+
+    let print_demangled = |sym: &str| {
+        let demangled = msvc_demangler::demangle(&sym, msvc_demangler::DemangleFlags::LotsOfWhitespace);
+        match demangled {
+            Ok(ref string) => println!("{}", string),
+            _ => println!("{}", sym),
+        }
+    };
+
+    if args.len() == 1 {
+        let stdin = io::stdin();
+        let handle = stdin.lock();
+
+        for line in handle.lines() {
+            match line {
+                Ok(line) => print_demangled(&line),
+                _ => continue,
+            }
+        }
+        return;
+    }
+
+    for (i, arg) in env::args().enumerate() {
+        if i == 0 {
+            continue;
+        }
+
+        print_demangled(&arg);
+    }
+}


### PR DESCRIPTION
c++filt is a useful tool to have for shell pipelines and whatnot.  No
reason we shouldn't have an MSVC-alike.