### PR TITLE
Fix member function pointers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1360,7 +1360,16 @@ impl<'a> Serializer<'a> {
             &Type::Array(len, ref inner, _sc) => {
                 write!(self.w, "[{}]", len)?;
                 self.write_post(inner)?;
-            }
+            },
+            &Type::CXXVFTable(ref names, _) => if !names.names.is_empty() {
+                write!(self.w, "{{for ")?;
+                for name in &names.names {
+                    write!(self.w, "`")?;
+                    self.write_one_name(name)?;
+                    write!(self.w, "'")?;
+                }
+                self.w.write(b"}")?;
+            },
             _ => {}
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub struct Symbol<'a> {
 pub enum Type<'a> {
     None,
     MemberFunction(FuncClass, CallingConv, Params<'a>, StorageClass, Box<Type<'a>>), // StorageClass is for the 'this' pointer
-    MemberFunctionPointer(Symbol<'a>, Params<'a>, StorageClass, Box<Type<'a>>),
+    MemberFunctionPointer(Symbol<'a>, CallingConv, Params<'a>, StorageClass, Box<Type<'a>>),
     NonMemberFunction(CallingConv, Params<'a>, StorageClass, Box<Type<'a>>),
     CXXVBTable(NameSequence<'a>, StorageClass),
     CXXVFTable(NameSequence<'a>, StorageClass),
@@ -788,12 +788,13 @@ impl<'a> ParserState<'a> {
             let symbol = self.read_name(true)?;
             let _is_64bit_ptr = self.expect(b"E")?;
             let access_class = self.read_qualifier();
-            let _calling_conv = self.read_calling_conv()?;
+            let calling_conv = self.read_calling_conv()?;
             let storage_class_for_return = self.read_storage_class_for_return()?;
             let return_type = self.read_func_return_type(storage_class_for_return)?;
             let params = self.read_func_params()?;
             return Ok(Type::MemberFunctionPointer(
                 symbol,
+                calling_conv,
                 params,
                 access_class,
                 Box::new(return_type),
@@ -1110,8 +1111,9 @@ impl<'a> Serializer<'a> {
                 self.write_calling_conv(calling_conv)?;
                 return Ok(());
             }
-            &Type::MemberFunctionPointer(ref symbol, _, _, ref inner) => {
+            &Type::MemberFunctionPointer(ref symbol, calling_conv, _, _, ref inner) => {
                 self.write_pre(inner)?;
+                self.write_calling_conv(calling_conv)?;
                 if self.flags == DemangleFlags::LotsOfWhitespace {
                     self.write_space()?;
                 }
@@ -1326,7 +1328,7 @@ impl<'a> Serializer<'a> {
                     }
                 }
             }
-            &Type::MemberFunctionPointer(_, ref params, sc, ref return_type) => {
+            &Type::MemberFunctionPointer(_, _, ref params, sc, ref return_type) => {
                 write!(self.w, "(")?;
                 self.write_types(&params.types)?;
                 write!(self.w, ")")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1656,6 +1656,14 @@ mod tests {
             "??_7W@?A@@6B@",
             "const `anonymous namespace`::W::`vftable'",
         );
+        expect(
+            "??_7?$RunnableMethodImpl@PEAVLazyIdleThread@mozilla@@P812@EAAXXZ$0A@$0A@$$V@detail@mozilla@@6BnsIRunnable@@@",
+            "const mozilla::detail::RunnableMethodImpl<class mozilla::LazyIdleThread *,void __cdecl (mozilla::LazyIdleThread::*)(void),0,0>::`vftable\'{for `nsIRunnable\'}",
+        );
+        expect_undname_failure(
+            "??_7?$RunnableMethodImpl@PEAVLazyIdleThread@mozilla@@P812@EAAXXZ$0A@$0A@$$V@detail@mozilla@@6BnsIRunnable@@@",
+            "const mozilla::detail::RunnableMethodImpl<class mozilla::LazyIdleThread * __ptr64,void __cdecl (mozilla::LazyIdleThread::*)(void) __ptr64,0,0>::`vftable\'{for `nsIRunnable\'}",
+        );
         expect("??1?$ns@$$CBVtxXP@@@@QAE@XZ",
                "public: __thiscall ns<class txXP const>::~ns<class txXP const>(void)");
         /* XXX: undname prints void (__thiscall*)(void *) for the parameter type. */


### PR DESCRIPTION
This series adds a couple tweaks so we can successfully demangle templates with qualified member function pointers.