### PR TITLE
Error API Cleanup

### DIFF
--- a/src/bin/undname.rs
+++ b/src/bin/undname.rs
@@ -18,7 +18,8 @@ fn main() {
     let print_demangled = |sym: &str| {
         let parsed = match msvc_demangler::parse(&sym) {
             Ok(parsed) => parsed,
-            Err(_) => {
+            Err(err) => {
+                eprintln!("error: {}", err);
                 println!("{}", sym);
                 return;
             }
@@ -30,7 +31,10 @@ fn main() {
         let demangled = msvc_demangler::serialize(&parsed, flags);
         match demangled {
             Ok(ref string) => println!("{}", string),
-            _ => println!("{}", sym),
+            Err(err) => {
+                eprintln!("error: {}", err);
+                println!("{}", sym);
+            }
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl fmt::Display for Error {
     }
 }
 
-pub type Result<T> = result::Result<T, Error>;
+type Result<T> = result::Result<T, Error>;
 
 bitflags! {
     pub struct StorageClass: u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,10 +666,7 @@ impl<'a> ParserState<'a> {
 
     fn expect(&mut self, s: &[u8]) -> Result<()> {
         if !self.consume(s) {
-            Err(self.fail_args(format_args!(
-                "{} expected",
-                str::from_utf8(s)?,
-            )))
+            Err(self.fail_args(format_args!("{} expected", str::from_utf8(s)?,)))
         } else {
             Ok(())
         }

--- a/tests/test_basics.rs
+++ b/tests/test_basics.rs
@@ -1,17 +1,21 @@
 extern crate msvc_demangler;
 
-use msvc_demangler::{demangle, DemangleFlags, Result};
+use msvc_demangler::{demangle, DemangleFlags};
 
 fn expect_with_flags(input: &str, reference: &str, flags: u32) {
-    let demangled: Result<_> = demangle(input, ::DemangleFlags::from_bits(flags).unwrap());
-    let reference: Result<_> = Ok(reference.to_owned());
-    assert_eq!(demangled, reference);
+    let demangled = demangle(input, ::DemangleFlags::from_bits(flags).unwrap());
+    let reference = reference.to_owned();
+    if let Ok(demangled) = demangled {
+        assert_eq!(demangled, reference);
+    } else {
+        panic!("{:?} != {:?}", demangled, Ok::<_, ()>(reference));
+    }
 }
 
 // For cases where undname demangles differently/better than we do.
 fn expect_failure(input: &str, reference: &str) {
-    let demangled: Result<_> = demangle(input, ::DemangleFlags::COMPLETE);
-    let reference: Result<_> = Ok(reference.to_owned());
+    let demangled = demangle(input, ::DemangleFlags::COMPLETE).unwrap();
+    let reference = reference.to_owned();
     assert_ne!(demangled, reference);
 }
 // std::basic_filebuf<char,struct std::char_traits<char> >::basic_filebuf<char,struct std::char_traits<char> >


### PR DESCRIPTION
This removes all obvious remaining panics (still need to check if there are other
operations that can panic such as slicing) and reforms the error interface as
outlined in #44

It now forces all operations that fail through a central interface which makes it easier
to debug. I wanted to also add a backtrace to the errors but that's overkill since they
are only needed for internal debugging. I found that adding panics temporarily to the
fail method is a good way to debug this thing.