### PR TITLE
fix: Support `?Q…@` productions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,8 +839,8 @@ impl<'a> ParserState<'a> {
 
     fn read_template_name(&mut self) -> Result<Name<'a>> {
         // Templates have their own context for backreferences.
-        let saved_memorized_names = mem::replace(&mut self.memorized_names, vec![]);
-        let saved_memorized_types = mem::replace(&mut self.memorized_types, vec![]);
+        let saved_memorized_names = mem::take(&mut self.memorized_names);
+        let saved_memorized_types = mem::take(&mut self.memorized_types);
         let name = self.read_unqualified_name(false)?; // how does wine deal with ??$?DM@std@@YA?AV?$complex@M@0@ABMABV10@@Z
         let template_params = self.read_params()?;
         let _ = mem::replace(&mut self.memorized_names, saved_memorized_names);
@@ -1303,7 +1303,7 @@ impl<'a> ParserState<'a> {
                 return Ok(Type::TemplateParameterWithIndex(n));
             }
             if self.consume(b"$BY") {
-                return Ok(self.read_array()?);
+                return self.read_array();
             }
             if self.consume(b"$Q") {
                 return Ok(Type::RValueRef(Box::new(self.read_pointee()?), sc));

--- a/tests/test_basics.rs
+++ b/tests/test_basics.rs
@@ -181,6 +181,11 @@ fn other_tests() {
         "?getFactory@SkImageShader@@UBEP6A?AV?$sk_sp@VSkFlattenable@@@@AAVSkReadBuffer@@@ZXZ",
         "public: virtual class sk_sp<class SkFlattenable> (__cdecl * __thiscall SkImageShader::getFactory(void) const)(class SkReadBuffer &)"
     );
+
+    expect(
+        "?Present1@?QIDXGISwapChain4@@CDXGISwapChain@@UAGJIIPBUDXGI_PRESENT_PARAMETERS@@@Z", 
+        "public: virtual long __stdcall CDXGISwapChain::[IDXGISwapChain4]::Present1(unsigned int,unsigned int,struct DXGI_PRESENT_PARAMETERS const *)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
I *think* this is when you use a concrete class as an explicit interface,
similar to what `<Type as Trait>` is in Rust, though not quite sure.

long time no see @mstange ;-)