### PR TITLE
fix: Parse MD5 mangled names

### DIFF
--- a/tests/test_basics.rs
+++ b/tests/test_basics.rs
@@ -184,7 +184,12 @@ fn other_tests() {
 
     expect(
         "?Present1@?QIDXGISwapChain4@@CDXGISwapChain@@UAGJIIPBUDXGI_PRESENT_PARAMETERS@@@Z", 
-        "public: virtual long __stdcall CDXGISwapChain::[IDXGISwapChain4]::Present1(unsigned int,unsigned int,struct DXGI_PRESENT_PARAMETERS const *)"
+        "public: virtual long __stdcall CDXGISwapChain::[IDXGISwapChain4]::Present1(unsigned int,unsigned int,struct DXGI_PRESENT_PARAMETERS const *)");
+
+    // An MD5 mangled name is "valid" but output as-is
+    expect(
+        "??@8ba8d245c9eca390356129098dbe9f73@",
+        "??@8ba8d245c9eca390356129098dbe9f73@",
     );
 }
 


### PR DESCRIPTION
They are parsed correctly, but just returned as their mangled form.